### PR TITLE
Server: Add list-attempt-headers endpoint

### DIFF
--- a/server/svix-server/src/core/message_app.rs
+++ b/server/svix-server/src/core/message_app.rs
@@ -202,7 +202,7 @@ impl TryFrom<endpoint::Model> for CreateMessageEndpoint {
                 .transpose()
                 .map_err(|_| err_validation!("Endpoint rate limit out of bounds"))?,
             first_failure_at: m.first_failure_at,
-            headers: m.headers,
+            headers: m.headers_dangerous,
             disabled: m.disabled,
             deleted: m.deleted,
         })

--- a/server/svix-server/src/db/models/endpoint.rs
+++ b/server/svix-server/src/db/models/endpoint.rs
@@ -3,7 +3,7 @@
 
 use crate::core::types::{
     ApplicationId, BaseId, EndpointHeaders, EndpointId, EndpointIdOrUid, EndpointSecretInternal,
-    EndpointUid, EventChannelSet, EventTypeNameSet, ExpiringSigningKeys,
+    EndpointUid, EventChannelSet, EventTypeNameSet, ExpiringSigningKeys, SanitizedHeaders,
 };
 use crate::{ctx, error};
 use chrono::Utc;
@@ -33,7 +33,18 @@ pub struct Model {
     pub uid: Option<EndpointUid>,
     pub old_keys: Option<ExpiringSigningKeys>,
     pub channels: Option<EventChannelSet>,
-    pub headers: Option<EndpointHeaders>,
+    #[sea_orm(column_name = "headers")]
+    // This field could contain sensitive information and should
+    // not be exposed or accessed casually:
+    pub headers_dangerous: Option<EndpointHeaders>,
+}
+
+impl Model {
+    pub fn sanitized_headers(&self) -> Option<SanitizedHeaders> {
+        self.headers_dangerous
+            .as_ref()
+            .map(|hdrs| hdrs.clone().into())
+    }
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/server/svix-server/src/db/models/messageattempt.rs
+++ b/server/svix-server/src/db/models/messageattempt.rs
@@ -58,6 +58,10 @@ impl ActiveModelBehavior for ActiveModel {
 }
 
 impl Entity {
+    pub fn secure_find_by_id(attempt_id: MessageAttemptId) -> Select<Entity> {
+        Self::find().filter(Column::Id.eq(attempt_id))
+    }
+
     pub fn secure_find_by_msg(msg_id: MessageId) -> Select<Entity> {
         Self::find().filter(Column::MsgId.eq(msg_id))
     }

--- a/server/svix-server/src/worker.rs
+++ b/server/svix-server/src/worker.rs
@@ -184,7 +184,7 @@ async fn process_endpoint_failure(
 }
 
 /// Sign a message
-fn sign_msg(
+pub fn sign_msg(
     main_secret: &Encryption,
     timestamp: i64,
     body: &str,
@@ -222,7 +222,7 @@ fn sign_msg(
 }
 
 /// Generates a set of headers for any one webhook event
-fn generate_msg_headers(
+pub fn generate_msg_headers(
     timestamp: i64,
     msg_id: &MessageId,
     signatures: String,


### PR DESCRIPTION
This adds support for listing message-attempt headers given a 
message and attempt id.
